### PR TITLE
adding Type support for HasComponent for world.cs

### DIFF
--- a/src/World.cs
+++ b/src/World.cs
@@ -132,6 +132,15 @@ public sealed class World
         return _archetypes.HasComponent(type, entity.Identity);
     }
 
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool HasComponent<T>(Entity entity, Type target) where T : struct
+    {
+        var target_entity = GetTypeEntity(target);
+
+        var type = StorageType.Create<T>(target_entity.Identity);
+        return _archetypes.HasComponent(type, entity.Identity);
+    }
+	
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AddComponent<T>(Entity entity, Entity target) where T : struct
     {


### PR DESCRIPTION
 You could assign relationships between Entity and Type but there was no functionality to check if world.HasComponent had a Type type. I used the functionality that already existed to turn Type's into Entitys under the hood. 

The below functionality was not possible to check if world.HasComponent for Type types before.
![image](https://github.com/Byteron/HypEcs/assets/10397579/19950ae8-65fe-4ef9-a44f-a8acd7e0d4ee)
