### PR TITLE
implement IEquatable to avoid boxing in dictionary

### DIFF
--- a/src/StorageType.cs
+++ b/src/StorageType.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace HypEcs;
 
-public struct StorageType : IComparable<StorageType>
+public struct StorageType : IComparable<StorageType>, IEquatable<StorageType>
 {
     public Type Type { get; private set; }
     public ulong Value { get; private set; }


### PR DESCRIPTION
Dictionary uses `IEquatable` internally, and `StorageType` only implements `IComparable`, so it will get boxed and result in memory allocations.

This fixes part of https://github.com/Byteron/RelEcs/issues/33